### PR TITLE
Fix get example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ public function get($key, $default = null)
 
 ```php
 $arrays->set('movies.the-thin-red-line.title', 'The Thin Red Line');
+
+$arrays->get('movies.the-thin-red-line.title'); // 'The Thin Red Line'
 ```
 
 ##### <a name="arrays_has"></a> Method: `has()`


### PR DESCRIPTION
Just fixed an error in the readme.md for the example of "get()" method